### PR TITLE
feat: support vscode, warp, claude-code, gemini-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ where `<client>` is one of the following:
 - `witsy`
 - `enconvo`
 - `cursor`
+- `warp` (outputs config to copy/paste into Warp's cloud-based settings)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ where `<client>` is one of the following:
 - `witsy`
 - `enconvo`
 - `cursor`
+- `vscode`
+- `gemini-cli`
+- `claude-code`
 - `warp` (outputs config to copy/paste into Warp's cloud-based settings)
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "install-mcp",
-  "version": "1.0.4",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "install-mcp",
-      "version": "1.0.4",
+      "version": "1.0.9",
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3",
@@ -9325,7 +9325,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9342,7 +9341,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9354,13 +9352,11 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9377,7 +9373,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9392,7 +9387,6 @@
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9404,13 +9398,11 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9426,7 +9418,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9475,7 +9466,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9494,7 +9484,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9506,7 +9495,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9526,7 +9514,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9542,7 +9529,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "4.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9557,7 +9543,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "8.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9573,7 +9558,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator/node_modules/pacote": {
       "version": "20.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9604,7 +9588,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9613,7 +9596,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9622,7 +9604,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "6.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9640,7 +9621,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "8.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9652,7 +9632,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9664,7 +9643,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9673,7 +9651,6 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "9.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9690,17 +9667,14 @@
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.3.2",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -9709,7 +9683,6 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9722,7 +9695,6 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9731,7 +9703,6 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9740,7 +9711,6 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9752,7 +9722,6 @@
     },
     "node_modules/npm/node_modules/aggregate-error": {
       "version": "3.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9765,7 +9734,6 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9774,7 +9742,6 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "6.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9786,25 +9753,21 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9820,7 +9783,6 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "2.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9832,7 +9794,6 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9841,7 +9802,6 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "19.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9864,7 +9824,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/chownr": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -9873,7 +9832,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/minizlib": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -9886,7 +9844,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -9901,7 +9858,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/p-map": {
       "version": "7.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9913,7 +9869,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/tar": {
       "version": "7.4.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -9930,7 +9885,6 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/yallist": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -9939,7 +9893,6 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9951,7 +9904,6 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -9960,7 +9912,6 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "4.1.0",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9975,7 +9926,6 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -9987,7 +9937,6 @@
     },
     "node_modules/npm/node_modules/clean-stack": {
       "version": "2.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -9996,7 +9945,6 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10009,7 +9957,6 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10018,7 +9965,6 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10030,19 +9976,16 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.6",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10056,7 +9999,6 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10071,7 +10013,6 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -10083,7 +10024,6 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.3.7",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10100,7 +10040,6 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "5.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -10109,29 +10048,24 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10140,19 +10074,16 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10161,7 +10092,6 @@
     },
     "node_modules/npm/node_modules/foreground-child": {
       "version": "3.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10177,7 +10107,6 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10189,7 +10118,6 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "10.4.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10209,13 +10137,11 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "8.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10227,13 +10153,11 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10246,7 +10170,6 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10259,10 +10182,8 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
@@ -10272,7 +10193,6 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10284,7 +10204,6 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10293,7 +10212,6 @@
     },
     "node_modules/npm/node_modules/indent-string": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10302,7 +10220,6 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10311,7 +10228,6 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "7.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10329,7 +10245,6 @@
     },
     "node_modules/npm/node_modules/ip-address": {
       "version": "9.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10342,7 +10257,6 @@
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10354,7 +10268,6 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "5.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10366,7 +10279,6 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10375,13 +10287,11 @@
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "3.4.3",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -10396,13 +10306,11 @@
     },
     "node_modules/npm/node_modules/jsbn": {
       "version": "1.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10411,7 +10319,6 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -10420,7 +10327,6 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
-      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -10429,19 +10335,16 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10454,7 +10357,6 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10473,7 +10375,6 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10494,7 +10395,6 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10506,7 +10406,6 @@
     },
     "node_modules/npm/node_modules/libnpmhook": {
       "version": "11.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10519,7 +10418,6 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10532,7 +10430,6 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10547,7 +10444,6 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "10.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10566,7 +10462,6 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10578,7 +10473,6 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10591,7 +10485,6 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10607,13 +10500,11 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "10.4.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "14.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10635,7 +10526,6 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
       "version": "1.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -10644,7 +10534,6 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "9.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10659,7 +10548,6 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10668,7 +10556,6 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10680,7 +10567,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10697,7 +10583,6 @@
     },
     "node_modules/npm/node_modules/minipass-fetch/node_modules/minizlib": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10710,7 +10595,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10722,7 +10606,6 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10734,7 +10617,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10746,7 +10628,6 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10758,7 +10639,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10770,7 +10650,6 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10782,7 +10661,6 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10795,7 +10673,6 @@
     },
     "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10807,7 +10684,6 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -10819,13 +10695,11 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10834,7 +10708,6 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "11.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10858,7 +10731,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -10867,7 +10739,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/minizlib": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -10880,7 +10751,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -10895,7 +10765,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
       "version": "7.4.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10912,7 +10781,6 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -10921,7 +10789,6 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "8.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10936,7 +10803,6 @@
     },
     "node_modules/npm/node_modules/nopt/node_modules/abbrev": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10945,7 +10811,6 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10959,7 +10824,6 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -10968,7 +10832,6 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -10980,7 +10843,6 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "7.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -10992,7 +10854,6 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11001,7 +10862,6 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "12.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11016,7 +10876,6 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "9.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11028,7 +10887,6 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "10.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11043,7 +10901,6 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "11.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11056,7 +10913,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "18.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11075,7 +10931,6 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch/node_modules/minizlib": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11088,7 +10943,6 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -11097,7 +10951,6 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11112,13 +10965,11 @@
     },
     "node_modules/npm/node_modules/package-json-from-dist": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "19.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11149,7 +11000,6 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11163,7 +11013,6 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11172,7 +11021,6 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "1.11.1",
-      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -11188,7 +11036,6 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "6.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11201,7 +11048,6 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11210,7 +11056,6 @@
     },
     "node_modules/npm/node_modules/proggy": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11219,7 +11064,6 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -11228,7 +11072,6 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "3.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -11237,13 +11080,11 @@
     },
     "node_modules/npm/node_modules/promise-inflight": {
       "version": "1.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11256,7 +11097,6 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11268,7 +11108,6 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
-      "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -11276,7 +11115,6 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11288,7 +11126,6 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11297,7 +11134,6 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11310,7 +11146,6 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11319,7 +11154,6 @@
     },
     "node_modules/npm/node_modules/rimraf": {
       "version": "5.0.10",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11334,14 +11168,11 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
-      "dev": true,
       "inBundle": true,
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.6.3",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -11353,7 +11184,6 @@
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11365,7 +11195,6 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11374,7 +11203,6 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11386,7 +11214,6 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11403,7 +11230,6 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/bundle": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11415,7 +11241,6 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/core": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -11424,7 +11249,6 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/sign": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11441,7 +11265,6 @@
     },
     "node_modules/npm/node_modules/sigstore/node_modules/@sigstore/verify": {
       "version": "2.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11455,7 +11278,6 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11465,7 +11287,6 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.8.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11479,7 +11300,6 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11493,7 +11313,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11503,7 +11322,6 @@
     },
     "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11513,13 +11331,11 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
-      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11529,19 +11345,16 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.20",
-      "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/sprintf-js": {
       "version": "1.1.3",
-      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11553,7 +11366,6 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11568,7 +11380,6 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11582,7 +11393,6 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11595,7 +11405,6 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11607,7 +11416,6 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "9.4.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11619,7 +11427,6 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.2.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11636,7 +11443,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11648,7 +11454,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11660,7 +11465,6 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11669,19 +11473,16 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11690,7 +11491,6 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11704,7 +11504,6 @@
     },
     "node_modules/npm/node_modules/tuf-js/node_modules/@tufjs/models": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11717,7 +11516,6 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11729,7 +11527,6 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11741,13 +11538,11 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
-      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -11757,7 +11552,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11767,7 +11561,6 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11776,13 +11569,11 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "3.0.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/which": {
       "version": "5.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11797,7 +11588,6 @@
     },
     "node_modules/npm/node_modules/which/node_modules/isexe": {
       "version": "3.1.1",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -11806,7 +11596,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11824,7 +11613,6 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11841,7 +11629,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11856,7 +11643,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -11868,13 +11654,11 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11891,7 +11675,6 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
-      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -11906,7 +11689,6 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "6.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -11919,7 +11701,6 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
-      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "install-mcp",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "A CLI tool to install and manage MCP servers.",
   "bin": {
     "install-mcp": "./bin/run"
@@ -83,6 +83,5 @@
     "commitizen": {
       "path": "cz-conventional-changelog"
     }
-  },
-  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -83,5 +83,6 @@
     "commitizen": {
       "path": "cz-conventional-changelog"
     }
-  }
+  },
+  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -69,6 +69,11 @@ const clientPaths: { [key: string]: ClientInstallTarget } = {
     type: 'file',
     path: 'no-local-config', // it's okay this isn't a real path, we never use it
   },
+  'gemini-cli': {
+    type: 'file',
+    path: path.join(homeDir, '.gemini', 'settings.json'),
+    localPath: path.join(process.cwd(), '.gemini', 'settings.json'),
+  },
 }
 
 export const clientNames = Object.keys(clientPaths)

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -65,6 +65,10 @@ const clientPaths: { [key: string]: ClientInstallTarget } = {
     path: path.join(homeDir, '.cursor', 'mcp.json'),
     localPath: path.join(process.cwd(), '.cursor', 'mcp.json'),
   },
+  warp: {
+    type: 'file',
+    path: 'no-local-config', // it's okay this isn't a real path, we never use it
+  },
 }
 
 export const clientNames = Object.keys(clientPaths)

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -102,6 +102,12 @@ const clientPaths: { [key: string]: ClientInstallTarget } = {
     localPath: path.join(process.cwd(), '.vscode', 'settings.json'),
     configKey: 'mcp.servers',
   },
+  'claude-code': {
+    type: 'file',
+    path: path.join(homeDir, '.claude.json'),
+    localPath: path.join(process.cwd(), '.mcp.json'),
+    configKey: 'mcpServers',
+  },
 }
 
 export const clientNames = Object.keys(clientPaths)

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -15,6 +15,7 @@ interface ClientFileTarget {
   type: 'file'
   path: string
   localPath?: string
+  configKey: string
 }
 type ClientInstallTarget = ClientFileTarget
 
@@ -24,15 +25,15 @@ const homeDir = os.homedir()
 const platformPaths = {
   win32: {
     baseDir: process.env.APPDATA || path.join(homeDir, 'AppData', 'Roaming'),
-    vscodePath: path.join('Code', 'User', 'globalStorage'),
+    vscodePath: path.join('Code', 'User'),
   },
   darwin: {
     baseDir: path.join(homeDir, 'Library', 'Application Support'),
-    vscodePath: path.join('Code', 'User', 'globalStorage'),
+    vscodePath: path.join('Code', 'User'),
   },
   linux: {
     baseDir: process.env.XDG_CONFIG_HOME || path.join(homeDir, '.config'),
-    vscodePath: path.join('Code/User/globalStorage'),
+    vscodePath: path.join('Code/User'),
   },
 }
 
@@ -42,41 +43,93 @@ const defaultClaudePath = path.join(baseDir, 'Claude', 'claude_desktop_config.js
 
 // Define client paths using the platform-specific base directories
 const clientPaths: { [key: string]: ClientInstallTarget } = {
-  claude: { type: 'file', path: defaultClaudePath },
+  claude: { type: 'file', path: defaultClaudePath, configKey: 'mcpServers' },
   cline: {
     type: 'file',
-    path: path.join(baseDir, vscodePath, 'saoudrizwan.claude-dev', 'settings', 'cline_mcp_settings.json'),
+    path: path.join(
+      baseDir,
+      vscodePath,
+      'globalStorage',
+      'saoudrizwan.claude-dev',
+      'settings',
+      'cline_mcp_settings.json',
+    ),
+    configKey: 'mcpServers',
   },
   'roo-cline': {
     type: 'file',
-    path: path.join(baseDir, vscodePath, 'rooveterinaryinc.roo-cline', 'settings', 'mcp_settings.json'),
+    path: path.join(
+      baseDir,
+      vscodePath,
+      'globalStorage',
+      'rooveterinaryinc.roo-cline',
+      'settings',
+      'mcp_settings.json',
+    ),
+    configKey: 'mcpServers',
   },
   windsurf: {
     type: 'file',
     path: path.join(homeDir, '.codeium', 'windsurf', 'mcp_config.json'),
+    configKey: 'mcpServers',
   },
-  witsy: { type: 'file', path: path.join(baseDir, 'Witsy', 'settings.json') },
+  witsy: { type: 'file', path: path.join(baseDir, 'Witsy', 'settings.json'), configKey: 'mcpServers' },
   enconvo: {
     type: 'file',
     path: path.join(homeDir, '.config', 'enconvo', 'mcp_config.json'),
+    configKey: 'mcpServers',
   },
   cursor: {
     type: 'file',
     path: path.join(homeDir, '.cursor', 'mcp.json'),
     localPath: path.join(process.cwd(), '.cursor', 'mcp.json'),
+    configKey: 'mcpServers',
   },
   warp: {
     type: 'file',
     path: 'no-local-config', // it's okay this isn't a real path, we never use it
+    configKey: 'mcpServers',
   },
   'gemini-cli': {
     type: 'file',
     path: path.join(homeDir, '.gemini', 'settings.json'),
     localPath: path.join(process.cwd(), '.gemini', 'settings.json'),
+    configKey: 'mcpServers',
+  },
+  vscode: {
+    type: 'file',
+    path: path.join(baseDir, vscodePath, 'settings.json'),
+    localPath: path.join(process.cwd(), '.vscode', 'settings.json'),
+    configKey: 'mcp.servers',
   },
 }
 
 export const clientNames = Object.keys(clientPaths)
+
+// Helper function to get nested value from an object using dot notation
+export function getNestedValue(obj: ClientConfig, path: string): ClientConfig | undefined {
+  const keys = path.split('.')
+  let current: ClientConfig | undefined = obj
+  for (const key of keys) {
+    if (current && typeof current === 'object' && key in current) {
+      current = current[key] as ClientConfig
+    } else {
+      return undefined
+    }
+  }
+  return current
+}
+
+// Helper function to set nested value in an object using dot notation
+export function setNestedValue(obj: ClientConfig, path: string, value: ClientConfig): void {
+  const keys = path.split('.')
+  const lastKey = keys.pop()!
+  const target = keys.reduce((current, key) => {
+    if (!current[key]) current[key] = {}
+    return current[key]
+  }, obj)
+  target[lastKey] = value
+}
 
 export function getConfigPath(client?: string, local?: boolean): ClientInstallTarget {
   const normalizedClient = client?.toLowerCase() || 'claude'
@@ -87,6 +140,7 @@ export function getConfigPath(client?: string, local?: boolean): ClientInstallTa
     return {
       type: 'file',
       path: path.join(path.dirname(defaultClaudePath), '..', client || 'claude', `${normalizedClient}_config.json`),
+      configKey: 'mcpServers',
     }
   }
 
@@ -107,20 +161,28 @@ export function readConfig(client: string, local?: boolean): ClientConfig {
     verbose(`Checking if config file exists at: ${configPath.path}`)
     if (!fs.existsSync(configPath.path)) {
       verbose('Config file not found, returning default empty config')
-      return { mcpServers: {} }
+      const defaultConfig: ClientConfig = {}
+      setNestedValue(defaultConfig, configPath.configKey, {})
+      return defaultConfig
     }
 
     verbose('Reading config file content')
     const rawConfig = JSON.parse(fs.readFileSync(configPath.path, 'utf8'))
     verbose(`Config loaded successfully: ${JSON.stringify(rawConfig, null, 2)}`)
 
-    return {
-      ...rawConfig,
-      mcpServers: rawConfig.mcpServers || {},
+    // Ensure the nested structure exists
+    const existingValue = getNestedValue(rawConfig, configPath.configKey)
+    if (!existingValue) {
+      setNestedValue(rawConfig, configPath.configKey, {})
     }
+
+    return rawConfig
   } catch (error) {
     verbose(`Error reading config: ${error instanceof Error ? error.stack : JSON.stringify(error)}`)
-    return { mcpServers: {} }
+    const configPath = getConfigPath(client, local)
+    const defaultConfig: ClientConfig = {}
+    setNestedValue(defaultConfig, configPath.configKey, {})
+    return defaultConfig
   }
 }
 
@@ -128,14 +190,30 @@ export function writeConfig(config: ClientConfig, client?: string, local?: boole
   verbose(`Writing config for client: ${client || 'default'}${local ? ' (local)' : ''}`)
   verbose(`Config data: ${JSON.stringify(config, null, 2)}`)
 
-  if (!config.mcpServers || typeof config.mcpServers !== 'object') {
-    verbose('Invalid mcpServers structure in config')
-    throw new Error('Invalid mcpServers structure')
-  }
-
   const configPath = getConfigPath(client, local)
 
+  const nestedValue = getNestedValue(config, configPath.configKey)
+  if (!nestedValue || typeof nestedValue !== 'object') {
+    verbose(`Invalid ${configPath.configKey} structure in config`)
+    throw new Error(`Invalid ${configPath.configKey} structure`)
+  }
+
   writeConfigFile(config, configPath)
+}
+
+// Helper function for deep merge
+function deepMerge(target: ClientConfig, source: ClientConfig): ClientConfig {
+  const result = { ...target }
+
+  for (const key in source) {
+    if (source[key] && typeof source[key] === 'object' && !Array.isArray(source[key])) {
+      result[key] = deepMerge(result[key] || {}, source[key] as ClientConfig)
+    } else {
+      result[key] = source[key]
+    }
+  }
+
+  return result
 }
 
 function writeConfigFile(config: ClientConfig, target: ClientFileTarget): void {
@@ -147,7 +225,9 @@ function writeConfigFile(config: ClientConfig, target: ClientFileTarget): void {
     fs.mkdirSync(configDir, { recursive: true })
   }
 
-  let existingConfig: ClientConfig = { mcpServers: {} }
+  let existingConfig: ClientConfig = {}
+  setNestedValue(existingConfig, target.configKey, {})
+
   try {
     if (fs.existsSync(target.path)) {
       verbose('Reading existing config file for merging')
@@ -160,10 +240,7 @@ function writeConfigFile(config: ClientConfig, target: ClientFileTarget): void {
   }
 
   verbose('Merging configs')
-  const mergedConfig = {
-    ...existingConfig,
-    ...config,
-  }
+  const mergedConfig = deepMerge(existingConfig, config)
   verbose(`Merged config: ${JSON.stringify(mergedConfig, null, 2)}`)
 
   verbose(`Writing config to file: ${target.path}`)

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -1,6 +1,6 @@
 import type { ArgumentsCamelCase, Argv } from 'yargs'
 import { logger } from '../logger'
-import { green, red } from 'picocolors'
+import { blue, green, red } from 'picocolors'
 import { clientNames, readConfig, writeConfig } from '../client-config'
 
 export interface InstallArgv {
@@ -104,6 +104,32 @@ export async function handler(argv: ArgumentsCamelCase<InstallArgv>) {
 
   const name = argv.name || inferNameFromInput(target)
   const command = buildCommand(target)
+
+  if (argv.client === 'warp') {
+    logger.log('')
+    logger.info('Warp requires a manual installation through their UI.')
+    logger.log('  Please copy the following configuration object and add it to your Warp MCP config:\n')
+    logger.log(
+      JSON.stringify(
+        {
+          [name]: {
+            command: isUrl(target) ? 'npx' : command.split(' ')[0],
+            args: isUrl(target) ? ['-y', 'supergateway', '--sse', target] : command.split(' ').slice(1),
+            env: {},
+            working_directory: null,
+            start_on_launch: true,
+          },
+        },
+        null,
+        2,
+      )
+        .split('\n')
+        .map((line) => green('  ' + line))
+        .join('\n'),
+    )
+    logger.box("Read Warp's documentation at", blue('https://docs.warp.dev/knowledge-and-collaboration/mcp'))
+    return
+  }
 
   logger.info(`Installing MCP server "${name}" for ${argv.client}${argv.local ? ' (locally)' : ''}`)
 


### PR DESCRIPTION
### Overview
As the title suggests, this PR adds support for installing to Claude Code, VS Code, the Gemini CLI, and, as much as possible, Warp. To accommodate VS Code and any other future services which store MCP configs in abnormal places in their config files, I added a `configKey` field to the client install targets configuration as well as a utility function to help put MCP configurations in the right place. 

### Note on Warp
Warp doesn't actually store a file on the user's computer for its configuration---all of its settings are stored in the cloud with no way of accessing them externally. Obviously, this means that this tool can't support Warp directly, but since the goal of this tool is simply to make installing MCPs easier, I decided to try to pursue that goal for Warp anyway. Instead of configuring the MCP for you, install-mcp now will simply give the user the MCP configuration JSON block to paste into their Warp settings. It also links to the Warp docs for more information.