### PR TITLE
feat: add header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,20 @@ The tool automatically:
 - Infers server names from package names or URLs (e.g., `mcp.example.com` → `mcp-example-com`)
 - Handles URL-based servers with supergateway SSE support
 
+### Headers Support
+
+You can pass headers for authentication or other purposes using the `--header` flag:
+
+```bash
+# Single header
+npx install-mcp https://api.example.com/mcp --client claude --header "Authorization: Bearer token123"
+
+# Multiple headers
+npx install-mcp https://api.example.com/mcp --client claude \
+  --header "Authorization: Bearer token123" \
+  --header "X-API-Key: secret-key"
+```
+
 where `<client>` is one of the following:
 
 - `claude`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "install-mcp",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "A CLI tool to install and manage MCP servers.",
   "bin": {
     "install-mcp": "./bin/run"


### PR DESCRIPTION
With this PR, you can now pass headers to be added to the MCP config. For stdio-configured servers, the headers just get passed via `--headers` to supergateway. For clients supporting the `url` config option, headers get passed as a `headers` field of type `Record<string, string>`. 