### PR TITLE
feat: migrate to mcp-remote for oauth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ npx install-mcp @org/mcp-server --client claude
 npx install-mcp 'npx some-mcp-server --custom-args' --client claude
 ```
 
-### SSE URLs (with automatic naming)
+### Remote URLs (with automatic naming)
 
 ```bash
-npx install-mcp https://mcp.example.com/server/sse --client claude
+npx install-mcp https://mcp.example.com/server --client claude
 ```
 
 The tool automatically:
@@ -37,7 +37,7 @@ The tool automatically:
 - Converts simple package names to `npx package-name`
 - Preserves full commands as-is
 - Infers server names from package names or URLs (e.g., `mcp.example.com` → `mcp-example-com`)
-- Handles URL-based servers with supergateway SSE support
+- Handles OAuth authentication for remote servers
 
 ### Headers Support
 
@@ -53,51 +53,39 @@ npx install-mcp https://api.example.com/mcp --client claude \
   --header "X-API-Key: secret-key"
 ```
 
-### Transport Methods for Remote Servers
+### OAuth Authentication for Remote Servers
 
-When installing remote servers (URLs), the CLI needs to know which transport method the server uses. There are two transport methods:
-
-- **Streamable HTTP** (modern, recommended)
-- **SSE** (legacy)
-
-The CLI handles this in several ways:
-
-#### Automatic Detection
-
-By default, the CLI will automatically detect the transport method:
+When installing remote servers (URLs), the CLI will ask if the server uses OAuth authentication:
 
 ```bash
 npx install-mcp https://api.example.com/mcp --client claude
-# Output: Detecting transport type... this may take a few seconds.
-# Output: We've detected that this server uses the streamable HTTP transport method. Is this correct? (Y/n)
+# Output: Does this server use OAuth authentication? (Y/n)
 ```
 
-If the detection succeeds, it will ask you to confirm. If you answer "no", it will use the other transport method.
+If you answer yes, the authentication flow:
 
-#### Manual Specification
-
-You can skip detection by specifying the transport method directly:
+- Runs automatically before installation
+- Handles OAuth flows seamlessly in the background
+- **Authentication state is shared globally** - once you authenticate with a server, that authentication is automatically available to all MCP clients
+- No need to re-authenticate when using the same server in different clients
 
 ```bash
-# For streamable HTTP servers
-npx install-mcp https://api.example.com/mcp --client claude --transport http
-
-# For legacy SSE servers
-npx install-mcp https://api.example.com/mcp --client claude --transport sse
+# Output: Running authentication for https://api.example.com/mcp
 ```
 
-#### Fallback to Manual Questions
-
-If auto-detection fails, the CLI will ask you directly:
+If authentication fails, you'll see:
 
 ```
-Could not auto-detect transport type, please answer the following questions:
-Does this server support the streamable HTTP transport method? (Y/n)
+Authentication failed. Use the client to authenticate.
 ```
 
-Note: This only applies to URL-based installations. Package names and custom commands don't require transport selection.
+If the server doesn't use OAuth (you answer no), the installation proceeds directly without authentication.
 
-where `<client>` is one of the following:
+This ensures secure access to remote servers while maintaining flexibility for servers that don't require OAuth.
+
+## Supported Clients
+
+The `--client` flag specifies which MCP client you're installing for:
 
 - `claude`
 - `cline`

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ npx install-mcp https://api.example.com/mcp --client claude
 # Output: Does this server use OAuth authentication? (Y/n)
 ```
 
+You can bypass this prompt using the `--oauth` flag:
+
+```bash
+# Automatically run OAuth authentication
+npx install-mcp https://api.example.com/mcp --client claude --oauth yes
+
+# Skip OAuth authentication entirely
+npx install-mcp https://api.example.com/mcp --client claude --oauth no
+```
+
 If you answer yes, the authentication flow:
 
 - Runs automatically before installation

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "install-mcp",
-  "version": "1.6.0",
+  "version": "1.1.0",
   "description": "A CLI tool to install and manage MCP servers.",
   "bin": {
     "install-mcp": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "install-mcp",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "A CLI tool to install and manage MCP servers.",
   "bin": {
     "install-mcp": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "install-mcp",
-  "version": "1.0.13",
+  "version": "1.6.0",
   "description": "A CLI tool to install and manage MCP servers.",
   "bin": {
     "install-mcp": "./bin/run"

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -123,8 +123,14 @@ describe('install command', () => {
         $0: 'install-mcp',
       }
 
+      // Mock OAuth prompt to return true
+      mockLogger.prompt.mockResolvedValueOnce(true)
+
       await handler(argv)
 
+      expect(mockLogger.prompt).toHaveBeenCalledWith('Does this server use OAuth authentication?', {
+        type: 'confirm',
+      })
       expect(mockLogger.info).toHaveBeenCalledWith('Running authentication for https://example.com/server')
       expect(mockSpawn).toHaveBeenCalledWith(
         'npx',
@@ -154,6 +160,9 @@ describe('install command', () => {
         $0: 'install-mcp',
       }
 
+      // Mock OAuth prompt to return true
+      mockLogger.prompt.mockResolvedValueOnce(true)
+
       // Mock authentication failure
       const mockChildProcess = new EventEmitter() as unknown as ChildProcess
       // Create a properly typed mock for the 'on' method
@@ -170,6 +179,39 @@ describe('install command', () => {
 
       expect(mockLogger.error).toHaveBeenCalledWith('Authentication failed. Use the client to authenticate.')
       expect(mockClientConfig.writeConfig).not.toHaveBeenCalled()
+    })
+
+    it('should skip authentication when server does not use OAuth', async () => {
+      const argv: ArgumentsCamelCase<InstallArgv> = {
+        client: 'cline',
+        target: 'https://example.com/server',
+        yes: true,
+        _: [],
+        $0: 'install-mcp',
+      }
+
+      // Mock OAuth prompt to return false
+      mockLogger.prompt.mockResolvedValueOnce(false)
+
+      await handler(argv)
+
+      expect(mockLogger.prompt).toHaveBeenCalledWith('Does this server use OAuth authentication?', {
+        type: 'confirm',
+      })
+      expect(mockSpawn).not.toHaveBeenCalled()
+      expect(mockLogger.info).not.toHaveBeenCalledWith('Running authentication for https://example.com/server')
+      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mcpServers: {
+            'example-com': {
+              command: 'npx',
+              args: ['-y', 'mcp-remote@latest', 'https://example.com/server'],
+            },
+          },
+        }),
+        'cline',
+        undefined,
+      )
     })
 
     it('should not run authentication for non-URL targets', async () => {
@@ -196,8 +238,14 @@ describe('install command', () => {
         $0: 'install-mcp',
       }
 
+      // Mock OAuth prompt to return true
+      mockLogger.prompt.mockResolvedValueOnce(true)
+
       await handler(argv)
 
+      expect(mockLogger.prompt).toHaveBeenCalledWith('Does this server use OAuth authentication?', {
+        type: 'confirm',
+      })
       expect(mockLogger.info).toHaveBeenCalledWith('Running authentication for https://example.com/server')
       expect(mockSpawn).toHaveBeenCalledWith(
         'npx',
@@ -441,6 +489,9 @@ describe('install command', () => {
         $0: 'install-mcp',
       }
 
+      // Mock OAuth prompt to return true
+      mockLogger.prompt.mockResolvedValueOnce(true)
+
       await handler(argv)
 
       expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
@@ -534,6 +585,9 @@ describe('install command', () => {
         $0: 'install-mcp',
       }
 
+      // Mock OAuth prompt to return true
+      mockLogger.prompt.mockResolvedValueOnce(true)
+
       await handler(argv)
 
       expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
@@ -555,6 +609,9 @@ describe('install command', () => {
         _: [],
         $0: 'install-mcp',
       }
+
+      // Mock OAuth prompt to return true
+      mockLogger.prompt.mockResolvedValueOnce(true)
 
       await handler(argv)
 

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -3,16 +3,18 @@ import type { ArgumentsCamelCase } from 'yargs'
 import { handler, InstallArgv } from './install'
 import * as clientConfig from '../client-config'
 import { logger } from '../logger'
-import * as detectTransport from '../detect-transport'
+import { spawn } from 'child_process'
+import type { ChildProcess } from 'child_process'
+import { EventEmitter } from 'events'
 
 // Mock dependencies
 jest.mock('../client-config')
 jest.mock('../logger')
-jest.mock('../detect-transport')
+jest.mock('child_process')
 
 const mockClientConfig = clientConfig as jest.Mocked<typeof clientConfig>
 const mockLogger = logger as jest.Mocked<typeof logger>
-const mockDetectTransport = detectTransport as jest.Mocked<typeof detectTransport>
+const mockSpawn = spawn as jest.MockedFunction<typeof spawn>
 
 describe('install command', () => {
   beforeEach(() => {
@@ -41,7 +43,18 @@ describe('install command', () => {
       configKey: 'mcpServers',
     })
     mockLogger.prompt.mockResolvedValue('test-package')
-    mockDetectTransport.detectMcpTransport.mockResolvedValue('unknown')
+
+    // Mock successful authentication by default
+    const mockChildProcess = new EventEmitter() as unknown as ChildProcess
+    // Create a properly typed mock for the 'on' method
+    const mockOn = jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+      if (event === 'close') {
+        setTimeout(() => handler(0), 0)
+      }
+      return mockChildProcess
+    })
+    mockChildProcess.on = mockOn as ChildProcess['on']
+    mockSpawn.mockReturnValue(mockChildProcess)
   })
 
   afterEach(() => {
@@ -101,7 +114,7 @@ describe('install command', () => {
       )
     })
 
-    it('should install URL with supergateway for non-direct-URL clients', async () => {
+    it('should install URL with mcp-remote for non-direct-URL clients', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
         client: 'cline',
         target: 'https://example.com/server',
@@ -110,167 +123,56 @@ describe('install command', () => {
         $0: 'install-mcp',
       }
 
-      // Mock auto-detection returns http and user confirms
-      mockDetectTransport.detectMcpTransport.mockResolvedValueOnce('http')
-      mockLogger.prompt.mockResolvedValueOnce(true) // confirms detected transport
-
       await handler(argv)
 
-      expect(mockDetectTransport.detectMcpTransport).toHaveBeenCalledWith('https://example.com/server', {
-        timeoutMs: 5000,
-        headers: undefined,
+      expect(mockLogger.info).toHaveBeenCalledWith('Running authentication for https://example.com/server')
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'npx',
+        ['-y', '-p', 'mcp-remote@latest', 'mcp-remote-client', 'https://example.com/server'],
+        { stdio: ['ignore', 'ignore', 'ignore'] },
+      )
+      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mcpServers: {
+            'example-com': {
+              command: 'npx',
+              args: ['-y', 'mcp-remote@latest', 'https://example.com/server'],
+            },
+          },
+        }),
+        'cline',
+        undefined,
+      )
+    })
+
+    it('should handle authentication failure for URL installation', async () => {
+      const argv: ArgumentsCamelCase<InstallArgv> = {
+        client: 'cline',
+        target: 'https://example.com/server',
+        yes: true,
+        _: [],
+        $0: 'install-mcp',
+      }
+
+      // Mock authentication failure
+      const mockChildProcess = new EventEmitter() as unknown as ChildProcess
+      // Create a properly typed mock for the 'on' method
+      const mockOn = jest.fn((event: string, handler: (...args: unknown[]) => void) => {
+        if (event === 'close') {
+          setTimeout(() => handler(1), 0) // Exit code 1 for failure
+        }
+        return mockChildProcess
       })
-      expect(mockLogger.info).toHaveBeenCalledWith('Detecting transport type... this may take a few seconds.')
-      expect(mockLogger.prompt).toHaveBeenCalledWith(
-        "We've detected that this server uses the streamable HTTP transport method. Is this correct?",
-        { type: 'confirm' },
-      )
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mcpServers: {
-            'example-com': {
-              command: 'npx',
-              args: ['-y', 'supergateway', '--streamableHttp', 'https://example.com/server'],
-            },
-          },
-        }),
-        'cline',
-        undefined,
-      )
-    })
-
-    it('should install URL with SSE transport when specified', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'cline',
-        target: 'https://example.com/server',
-        transport: 'sse',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
+      mockChildProcess.on = mockOn as ChildProcess['on']
+      mockSpawn.mockReturnValueOnce(mockChildProcess)
 
       await handler(argv)
 
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mcpServers: {
-            'example-com': {
-              command: 'npx',
-              args: ['-y', 'supergateway', '--sse', 'https://example.com/server'],
-            },
-          },
-        }),
-        'cline',
-        undefined,
-      )
-    })
-
-    it('should install URL with HTTP transport when specified', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'cline',
-        target: 'https://example.com/server',
-        transport: 'http',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      await handler(argv)
-
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mcpServers: {
-            'example-com': {
-              command: 'npx',
-              args: ['-y', 'supergateway', '--streamableHttp', 'https://example.com/server'],
-            },
-          },
-        }),
-        'cline',
-        undefined,
-      )
-    })
-
-    it('should prompt for transport when URL provided without transport flag', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'cline',
-        target: 'https://example.com/server',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      // Mock auto-detection returns http and user confirms
-      mockDetectTransport.detectMcpTransport.mockResolvedValueOnce('http')
-      mockLogger.prompt.mockResolvedValueOnce(true) // confirms detected transport
-
-      await handler(argv)
-
-      expect(mockLogger.prompt).toHaveBeenCalledWith(
-        "We've detected that this server uses the streamable HTTP transport method. Is this correct?",
-        { type: 'confirm' },
-      )
-    })
-
-    it('should fall back to SSE when HTTP is not supported', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'cline',
-        target: 'https://example.com/server',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      // Mock auto-detection returns unknown, then manual prompts
-      mockDetectTransport.detectMcpTransport.mockResolvedValueOnce('unknown')
-      mockLogger.prompt
-        .mockResolvedValueOnce(false) // doesn't support streamable HTTP
-        .mockResolvedValueOnce(true) // uses legacy SSE
-
-      await handler(argv)
-
-      expect(mockLogger.prompt).toHaveBeenCalledWith('Does your server use the legacy SSE transport method?', {
-        type: 'confirm',
-      })
-
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mcpServers: {
-            'example-com': {
-              command: 'npx',
-              args: ['-y', 'supergateway', '--sse', 'https://example.com/server'],
-            },
-          },
-        }),
-        'cline',
-        undefined,
-      )
-    })
-
-    it('should error when neither transport is supported', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'cline',
-        target: 'https://example.com/server',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      // Mock auto-detection returns unknown, then manual prompts fail
-      mockDetectTransport.detectMcpTransport.mockResolvedValueOnce('unknown')
-      mockLogger.prompt
-        .mockResolvedValueOnce(false) // doesn't support streamable HTTP
-        .mockResolvedValueOnce(false) // doesn't use legacy SSE
-
-      await handler(argv)
-
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        'Remote servers must support either streamable HTTP or legacy SSE transport method.',
-      )
+      expect(mockLogger.error).toHaveBeenCalledWith('Authentication failed. Use the client to authenticate.')
       expect(mockClientConfig.writeConfig).not.toHaveBeenCalled()
     })
 
-    it('should not prompt for transport for non-URL targets', async () => {
+    it('should not run authentication for non-URL targets', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
         client: 'claude',
         target: 'test-package',
@@ -281,11 +183,11 @@ describe('install command', () => {
 
       await handler(argv)
 
-      // Should not have prompted for transport
-      expect(mockLogger.prompt).not.toHaveBeenCalledWith(expect.stringContaining('transport'), expect.any(Object))
+      // Should not have run authentication
+      expect(mockSpawn).not.toHaveBeenCalled()
     })
 
-    it('should install URL directly for cursor/claude/vscode clients', async () => {
+    it('should install URL with mcp-remote for cursor/claude/vscode clients', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
         client: 'cursor',
         target: 'https://example.com/server',
@@ -294,17 +196,20 @@ describe('install command', () => {
         $0: 'install-mcp',
       }
 
-      // Mock auto-detection returns http and user confirms
-      mockDetectTransport.detectMcpTransport.mockResolvedValueOnce('http')
-      mockLogger.prompt.mockResolvedValueOnce(true) // confirms detected transport
-
       await handler(argv)
 
+      expect(mockLogger.info).toHaveBeenCalledWith('Running authentication for https://example.com/server')
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'npx',
+        ['-y', '-p', 'mcp-remote@latest', 'mcp-remote-client', 'https://example.com/server'],
+        { stdio: ['ignore', 'ignore', 'ignore'] },
+      )
       expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           mcpServers: {
             'example-com': {
-              url: 'https://example.com/server',
+              command: 'npx',
+              args: ['-y', 'mcp-remote@latest', 'https://example.com/server'],
             },
           },
         }),
@@ -338,32 +243,7 @@ describe('install command', () => {
       )
     })
 
-    it('should handle npx command', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'claude',
-        target: 'npx -y @modelcontextprotocol/server-filesystem',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      await handler(argv)
-
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mcpServers: {
-            '@modelcontextprotocol/server-filesystem': {
-              command: 'npx',
-              args: ['-y', '@modelcontextprotocol/server-filesystem'],
-            },
-          },
-        }),
-        'claude',
-        undefined,
-      )
-    })
-
-    it('should use custom name if provided', async () => {
+    it('should install with custom name', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
         client: 'claude',
         target: 'test-package',
@@ -389,91 +269,7 @@ describe('install command', () => {
       )
     })
 
-    it('should install locally when local flag is set', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'claude',
-        target: 'test-package',
-        local: true,
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      await handler(argv)
-
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(expect.anything(), 'claude', true)
-    })
-
-    it('should handle warp client with manual instructions', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'warp',
-        target: 'test-package',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      await handler(argv)
-
-      expect(mockLogger.info).toHaveBeenCalledWith(expect.stringContaining('Warp requires a manual installation'))
-      expect(mockLogger.box).toHaveBeenCalledWith(
-        expect.stringContaining("Read Warp's documentation"),
-        expect.any(String),
-      )
-    })
-
-    it('should handle warp client with URL', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'warp',
-        target: 'https://example.com/server',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      // Mock auto-detection returns http and user confirms
-      mockDetectTransport.detectMcpTransport.mockResolvedValueOnce('http')
-      mockLogger.prompt.mockResolvedValueOnce(true) // confirms detected transport
-
-      await handler(argv)
-
-      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('"command": "npx"'))
-      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('--streamableHttp'))
-    })
-
-    it('should handle warp client with SSE transport', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'warp',
-        target: 'https://example.com/server',
-        transport: 'sse',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      await handler(argv)
-
-      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('"command": "npx"'))
-      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('--sse'))
-    })
-
-    it('should handle warp client with HTTP transport', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'warp',
-        target: 'https://example.com/server',
-        transport: 'http',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      await handler(argv)
-
-      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('"command": "npx"'))
-      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('--streamableHttp'))
-    })
-
-    it('should prompt for confirmation when yes flag is not set', async () => {
+    it('should prompt for confirmation when not using --yes', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
         client: 'claude',
         target: 'test-package',
@@ -485,10 +281,13 @@ describe('install command', () => {
 
       await handler(argv)
 
-      expect(mockLogger.prompt).toHaveBeenCalledWith(expect.stringContaining('Install MCP server'), { type: 'confirm' })
+      expect(mockLogger.prompt).toHaveBeenCalledWith(
+        expect.stringContaining('Install MCP server "test-package" in claude?'),
+        { type: 'confirm' },
+      )
     })
 
-    it('should not install if user declines confirmation', async () => {
+    it('should not install when user cancels', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
         client: 'claude',
         target: 'test-package',
@@ -503,49 +302,11 @@ describe('install command', () => {
       expect(mockClientConfig.writeConfig).not.toHaveBeenCalled()
     })
 
-    it('should handle writeConfig error', async () => {
+    it('should handle local installation', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
         client: 'claude',
         target: 'test-package',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      mockClientConfig.writeConfig.mockImplementation(() => {
-        throw new Error('Write error')
-      })
-
-      await handler(argv)
-
-      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Write error'))
-    })
-
-    it('should handle vscode with nested config key', async () => {
-      mockClientConfig.getConfigPath.mockReturnValue({
-        type: 'file',
-        path: '/test/config.json',
-        configKey: 'mcp.servers',
-      })
-
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'vscode',
-        target: 'test-package',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      await handler(argv)
-
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(expect.any(Object), 'vscode', undefined)
-    })
-
-    it('should handle headers with URL installation', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'cursor',
-        target: 'https://example.com/server',
-        header: ['Authorization: Bearer token123', 'X-Custom-Header: value'],
+        local: true,
         yes: true,
         _: [],
         $0: 'install-mcp',
@@ -554,28 +315,127 @@ describe('install command', () => {
       await handler(argv)
 
       expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
+        expect.any(Object),
+        'claude',
+        true, // local flag
+      )
+    })
+
+    it('should handle warp client differently', async () => {
+      const argv: ArgumentsCamelCase<InstallArgv> = {
+        client: 'warp',
+        target: 'test-package',
+        yes: true,
+        _: [],
+        $0: 'install-mcp',
+      }
+
+      await handler(argv)
+
+      expect(mockLogger.info).toHaveBeenCalledWith('Warp requires a manual installation through their UI.')
+      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('"test-package"'))
+      expect(mockClientConfig.writeConfig).not.toHaveBeenCalled()
+    })
+
+    it('should handle warp client with URL', async () => {
+      const argv: ArgumentsCamelCase<InstallArgv> = {
+        client: 'warp',
+        target: 'https://example.com/server',
+        yes: true,
+        _: [],
+        $0: 'install-mcp',
+      }
+
+      await handler(argv)
+
+      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('"mcp-remote@latest"'))
+      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('"https://example.com/server"'))
+    })
+
+    it('should handle different config structures', async () => {
+      const argv: ArgumentsCamelCase<InstallArgv> = {
+        client: 'vscode',
+        target: 'test-package',
+        yes: true,
+        _: [],
+        $0: 'install-mcp',
+      }
+
+      mockClientConfig.getConfigPath.mockReturnValue({
+        type: 'file',
+        path: '/test/settings.json',
+        configKey: 'mcp.servers',
+      })
+
+      // Mock the config to have the nested structure for VSCode
+      mockClientConfig.readConfig.mockReturnValue({ mcp: { servers: {} } })
+
+      await handler(argv)
+
+      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
         expect.objectContaining({
-          mcpServers: {
-            'example-com': {
-              url: 'https://example.com/server',
-              headers: {
-                Authorization: 'Bearer token123',
-                'X-Custom-Header': 'value',
+          mcp: {
+            servers: {
+              'test-package': {
+                command: 'npx',
+                args: ['test-package'],
               },
             },
           },
         }),
-        'cursor',
+        'vscode',
         undefined,
       )
     })
 
-    it('should handle headers with supergateway and different transports', async () => {
+    it('should handle existing servers in config', async () => {
+      const argv: ArgumentsCamelCase<InstallArgv> = {
+        client: 'claude',
+        target: 'new-package',
+        yes: true,
+        _: [],
+        $0: 'install-mcp',
+      }
+
+      mockClientConfig.readConfig.mockReturnValue({
+        mcpServers: {
+          'existing-server': {
+            command: 'node',
+            args: ['existing.js'],
+          },
+        },
+      })
+
+      mockClientConfig.getNestedValue.mockImplementation((obj, path) => {
+        if (path === 'mcpServers') return obj.mcpServers
+        return undefined
+      })
+
+      await handler(argv)
+
+      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mcpServers: {
+            'existing-server': {
+              command: 'node',
+              args: ['existing.js'],
+            },
+            'new-package': {
+              command: 'npx',
+              args: ['new-package'],
+            },
+          },
+        }),
+        'claude',
+        undefined,
+      )
+    })
+
+    it('should handle headers with URL installation', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
         client: 'cline',
         target: 'https://example.com/server',
-        header: ['Authorization: Bearer token123'],
-        transport: 'http',
+        header: ['Authorization: Bearer token123', 'X-Custom: value'],
         yes: true,
         _: [],
         $0: 'install-mcp',
@@ -590,11 +450,12 @@ describe('install command', () => {
               command: 'npx',
               args: [
                 '-y',
-                'supergateway',
-                '--streamableHttp',
+                'mcp-remote@latest',
                 'https://example.com/server',
                 '--header',
                 'Authorization: Bearer token123',
+                '--header',
+                'X-Custom: value',
               ],
             },
           },
@@ -604,107 +465,9 @@ describe('install command', () => {
       )
     })
 
-    it('should auto-detect SSE transport and install with confirmation', async () => {
+    it('should handle headers with warp client', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'cline',
-        target: 'https://example.com/server',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      // Mock auto-detection returns sse and user confirms
-      mockDetectTransport.detectMcpTransport.mockResolvedValueOnce('sse')
-      mockLogger.prompt.mockResolvedValueOnce(true) // confirms detected transport
-
-      await handler(argv)
-
-      expect(mockLogger.prompt).toHaveBeenCalledWith(
-        "We've detected that this server uses the SSE transport method. Is this correct?",
-        { type: 'confirm' },
-      )
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mcpServers: {
-            'example-com': {
-              command: 'npx',
-              args: ['-y', 'supergateway', '--sse', 'https://example.com/server'],
-            },
-          },
-        }),
-        'cline',
-        undefined,
-      )
-    })
-
-    it('should use opposite transport when user rejects auto-detection', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'cline',
-        target: 'https://example.com/server',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      // Mock auto-detection returns http but user rejects it
-      mockDetectTransport.detectMcpTransport.mockResolvedValueOnce('http')
-      mockLogger.prompt.mockResolvedValueOnce(false) // rejects detected transport
-
-      await handler(argv)
-
-      expect(mockLogger.info).toHaveBeenCalledWith('Installing as SSE transport method.')
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mcpServers: {
-            'example-com': {
-              command: 'npx',
-              args: ['-y', 'supergateway', '--sse', 'https://example.com/server'],
-            },
-          },
-        }),
-        'cline',
-        undefined,
-      )
-    })
-
-    it('should fall back to manual questions when auto-detection returns unknown', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'cline',
-        target: 'https://example.com/server',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      // Mock auto-detection returns unknown
-      mockDetectTransport.detectMcpTransport.mockResolvedValueOnce('unknown')
-      mockLogger.prompt.mockResolvedValueOnce(true) // supports streamable HTTP
-
-      await handler(argv)
-
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        'Could not auto-detect transport type, please answer the following questions:',
-      )
-      expect(mockLogger.prompt).toHaveBeenCalledWith('Does this server support the streamable HTTP transport method?', {
-        type: 'confirm',
-      })
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mcpServers: {
-            'example-com': {
-              command: 'npx',
-              args: ['-y', 'supergateway', '--streamableHttp', 'https://example.com/server'],
-            },
-          },
-        }),
-        'cline',
-        undefined,
-      )
-    })
-
-    it('should pass headers to detectMcpTransport when provided', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'cline',
+        client: 'warp',
         target: 'https://example.com/server',
         header: ['Authorization: Bearer token123'],
         yes: true,
@@ -712,26 +475,60 @@ describe('install command', () => {
         $0: 'install-mcp',
       }
 
-      // Mock auto-detection returns http and user confirms
-      mockDetectTransport.detectMcpTransport.mockResolvedValueOnce('http')
-      mockLogger.prompt.mockResolvedValueOnce(true) // confirms detected transport
+      await handler(argv)
+
+      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('"--header"'))
+      expect(mockLogger.log).toHaveBeenCalledWith(expect.stringContaining('"Authorization: Bearer token123"'))
+    })
+
+    it('should handle error during write', async () => {
+      const argv: ArgumentsCamelCase<InstallArgv> = {
+        client: 'claude',
+        target: 'test-package',
+        yes: true,
+        _: [],
+        $0: 'install-mcp',
+      }
+
+      const error = new Error('Write failed')
+      mockClientConfig.writeConfig.mockImplementation(() => {
+        throw error
+      })
 
       await handler(argv)
 
-      expect(mockDetectTransport.detectMcpTransport).toHaveBeenCalledWith('https://example.com/server', {
-        timeoutMs: 5000,
-        headers: {
-          Authorization: 'Bearer token123',
-        },
-      })
+      expect(mockLogger.error).toHaveBeenCalledWith(expect.stringContaining('Write failed'))
     })
-  })
 
-  describe('name inference', () => {
+    it('should infer name from npx command', async () => {
+      const argv: ArgumentsCamelCase<InstallArgv> = {
+        client: 'claude',
+        target: 'npx -y @org/mcp-server',
+        yes: true,
+        _: [],
+        $0: 'install-mcp',
+      }
+
+      await handler(argv)
+
+      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
+        expect.objectContaining({
+          mcpServers: {
+            '@org/mcp-server': {
+              command: 'npx',
+              args: ['-y', '@org/mcp-server'],
+            },
+          },
+        }),
+        'claude',
+        undefined,
+      )
+    })
+
     it('should infer name from URL', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
         client: 'claude',
-        target: 'https://api.example.com/server',
+        target: 'https://api.example.com/mcp',
         yes: true,
         _: [],
         $0: 'install-mcp',
@@ -750,54 +547,10 @@ describe('install command', () => {
       )
     })
 
-    it('should infer name from npx command', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'claude',
-        target: 'npx -y @test/package',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      await handler(argv)
-
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mcpServers: {
-            '@test/package': expect.any(Object),
-          },
-        }),
-        'claude',
-        undefined,
-      )
-    })
-
-    it('should infer name from node command', async () => {
-      const argv: ArgumentsCamelCase<InstallArgv> = {
-        client: 'claude',
-        target: 'node script.js',
-        yes: true,
-        _: [],
-        $0: 'install-mcp',
-      }
-
-      await handler(argv)
-
-      expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
-        expect.objectContaining({
-          mcpServers: {
-            node: expect.any(Object),
-          },
-        }),
-        'claude',
-        undefined,
-      )
-    })
-
     it('should handle malformed URL', async () => {
       const argv: ArgumentsCamelCase<InstallArgv> = {
         client: 'claude',
-        target: 'https://malformed/url/path',
+        target: 'https://[invalid-url',
         yes: true,
         _: [],
         $0: 'install-mcp',
@@ -808,7 +561,7 @@ describe('install command', () => {
       expect(mockClientConfig.writeConfig).toHaveBeenCalledWith(
         expect.objectContaining({
           mcpServers: {
-            malformed: expect.any(Object),
+            '[invalid-url': expect.any(Object),
           },
         }),
         'claude',

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -212,11 +212,18 @@ export async function handler(argv: ArgumentsCamelCase<InstallArgv>) {
 
   if (ready) {
     if (isUrl(target)) {
-      try {
-        await runAuthentication(target)
-      } catch {
-        logger.error('Authentication failed. Use the client to authenticate.')
-        return
+      // Ask if the server uses OAuth
+      const usesOAuth = await logger.prompt('Does this server use OAuth authentication?', {
+        type: 'confirm',
+      })
+      
+      if (usesOAuth) {
+        try {
+          await runAuthentication(target)
+        } catch {
+          logger.error('Authentication failed. Use the client to authenticate.')
+          return
+        }
       }
     }
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -10,7 +10,7 @@ import {
   setNestedValue,
   type ClientConfig,
 } from '../client-config'
-import { detectMcpTransport } from '../detect-transport'
+import { spawn } from 'child_process'
 
 // Helper to set a server config in a nested structure
 function setServerConfig(
@@ -39,7 +39,6 @@ export interface InstallArgv {
   local?: boolean
   yes?: boolean
   header?: string[]
-  transport?: 'sse' | 'http'
 }
 
 export const command = '$0 [target]'
@@ -76,12 +75,6 @@ export function builder(yargs: Argv<InstallArgv>): Argv {
       description: 'Headers to pass to the server (format: "Header: value")',
       default: [],
     })
-    .option('transport', {
-      type: 'string',
-      alias: 't',
-      description: 'Transport protocol for URL servers (sse or http)',
-      choices: ['sse', 'http'],
-    } as const)
 }
 
 function isUrl(input: string): boolean {
@@ -131,19 +124,24 @@ function buildCommand(input: string): string {
   }
 }
 
-function parseHeaders(headers: string[]): Record<string, string> {
-  const parsedHeaders: Record<string, string> = {}
-  for (const header of headers) {
-    const colonIndex = header.indexOf(':')
-    if (colonIndex !== -1) {
-      const name = header.substring(0, colonIndex).trim()
-      const value = header.substring(colonIndex + 1).trim()
-      if (name && value) {
-        parsedHeaders[name] = value
+// Run the authentication flow for remote servers before installation.
+async function runAuthentication(url: string): Promise<void> {
+  logger.info(`Running authentication for ${url}`)
+  return new Promise((resolve, reject) => {
+    const child = spawn('npx', ['-y', '-p', 'mcp-remote@latest', 'mcp-remote-client', url], {
+      stdio: ['ignore', 'ignore', 'ignore'], // Hide all output
+    })
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve()
+      } else {
+        reject(new Error(`Authentication exited with code ${code}`))
       }
-    }
-  }
-  return parsedHeaders
+    })
+
+    child.on('error', reject)
+  })
 }
 
 export async function handler(argv: ArgumentsCamelCase<InstallArgv>) {
@@ -159,61 +157,6 @@ export async function handler(argv: ArgumentsCamelCase<InstallArgv>) {
     })) as string
   }
 
-  // Prompt for transport if target is a URL and transport not specified
-  let transport = argv.transport
-  if (isUrl(target) && !transport) {
-    // Try to auto-detect the transport type
-    logger.info('Detecting transport type... this may take a few seconds.')
-
-    const detectedTransport = await detectMcpTransport(target, {
-      timeoutMs: 5000,
-      headers: argv.header ? parseHeaders(argv.header) : undefined,
-    })
-
-    if (detectedTransport === 'http' || detectedTransport === 'sse') {
-      // We detected a transport type, ask for confirmation
-      const transportDisplay = detectedTransport === 'http' ? 'streamable HTTP' : 'SSE'
-      const confirmed = await logger.prompt(
-        `We've detected that this server uses the ${transportDisplay} transport method. Is this correct?`,
-        { type: 'confirm' },
-      )
-
-      if (confirmed) {
-        transport = detectedTransport
-      } else {
-        // User said no, use the other transport method
-        transport = detectedTransport === 'http' ? 'sse' : 'http'
-        const otherTransportDisplay = transport === 'http' ? 'streamable HTTP' : 'SSE'
-        logger.info(`Installing as ${otherTransportDisplay} transport method.`)
-      }
-    } else {
-      // Detection failed, fall back to manual questions
-      logger.info('Could not auto-detect transport type, please answer the following questions:')
-
-      // Ask about streamable HTTP first (default yes)
-      const supportsStreamableHttp = await logger.prompt(
-        'Does this server support the streamable HTTP transport method?',
-        { type: 'confirm' },
-      )
-
-      if (supportsStreamableHttp) {
-        transport = 'http'
-      } else {
-        // Ask about legacy SSE (default no, but if they said no to HTTP, we need to confirm SSE)
-        const usesLegacySSE = await logger.prompt('Does your server use the legacy SSE transport method?', {
-          type: 'confirm',
-        })
-
-        if (usesLegacySSE) {
-          transport = 'sse'
-        } else {
-          logger.error('Remote servers must support either streamable HTTP or legacy SSE transport method.')
-          return
-        }
-      }
-    }
-  }
-
   const name = argv.name || inferNameFromInput(target)
   const command = buildCommand(target)
 
@@ -225,8 +168,7 @@ export async function handler(argv: ArgumentsCamelCase<InstallArgv>) {
     // Build args array for Warp
     let warpArgs: string[]
     if (isUrl(target)) {
-      const transportFlag = transport === 'http' ? '--streamableHttp' : '--sse'
-      warpArgs = ['-y', 'supergateway', transportFlag, target]
+      warpArgs = ['-y', 'mcp-remote@latest', target]
       // Add headers as arguments for supergateway
       if (argv.header && argv.header.length > 0) {
         for (const header of argv.header) {
@@ -269,6 +211,15 @@ export async function handler(argv: ArgumentsCamelCase<InstallArgv>) {
   }
 
   if (ready) {
+    if (isUrl(target)) {
+      try {
+        await runAuthentication(target)
+      } catch {
+        logger.error('Authentication failed. Use the client to authenticate.')
+        return
+      }
+    }
+
     try {
       const config = readConfig(argv.client, argv.local)
       const configPath = getConfigPath(argv.client, argv.local)
@@ -276,32 +227,18 @@ export async function handler(argv: ArgumentsCamelCase<InstallArgv>) {
 
       if (isUrl(target)) {
         // URL-based installation
-        if (['cursor', 'vscode'].includes(argv.client)) {
-          const serverConfig: ClientConfig = {
-            url: target,
+
+        const args = ['-y', 'mcp-remote@latest', target]
+        // Add headers as arguments for supergateway
+        if (argv.header && argv.header.length > 0) {
+          for (const header of argv.header) {
+            args.push('--header', header)
           }
-          // Add headers if provided
-          if (argv.header && argv.header.length > 0) {
-            const parsedHeaders = parseHeaders(argv.header)
-            if (Object.keys(parsedHeaders).length > 0) {
-              serverConfig.headers = parsedHeaders
-            }
-          }
-          setServerConfig(config, configKey, name, serverConfig)
-        } else {
-          const transportFlag = transport === 'http' ? '--streamableHttp' : '--sse'
-          const args = ['-y', 'supergateway', transportFlag, target]
-          // Add headers as arguments for supergateway
-          if (argv.header && argv.header.length > 0) {
-            for (const header of argv.header) {
-              args.push('--header', header)
-            }
-          }
-          setServerConfig(config, configKey, name, {
-            command: 'npx',
-            args: args,
-          })
         }
+        setServerConfig(config, configKey, name, {
+          command: 'npx',
+          args: args,
+        })
       } else {
         // Command-based installation (including simple package names)
         const cmdParts = command.split(' ')


### PR DESCRIPTION
## Overview

This PR switches from `supergateway` to `mcp-remote` to support oauth MCP servers on all clients. 

### Changes

- **Removed transport detection**: No more asking users about SSE vs HTTP transport methods. The `mcp-remote` package handles this automatically now.

- **Added OAuth authentication**: When installing a remote server, the CLI now asks if it uses OAuth. If yes, it runs the auth flow before installation so that it won't fall on the client to trigger this properly, which they evidently don't (looking at you, Cursor).

- **Added `--oauth` flag**: You can bypass the OAuth prompt with `--oauth yes` or `--oauth no` for scripting/automation.

- **Shared auth state**: Once you authenticate with a server, that auth is automatically available to all MCP clients - no need to re-authenticate.

### Breaking changes

- Removed `--transport` flag and all transport-related options
- Remote servers now use `mcp-remote` instead of `supergateway`