### PR TITLE
feat: add `--project` option to specify project for supermemory

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,31 @@ The tool automatically:
 - Infers server names from package names or URLs (e.g., `mcp.example.com` → `mcp-example-com`)
 - Handles OAuth authentication for remote servers
 
+### Supermemory project support
+
+When installing a server hosted on `https://api.supermemory.ai/*`, you can pass a project name via `--project`. This is a convenience alias for adding the header `x-sm-project: <value>`.
+
+Rules:
+
+- Only applies to URL installs targeting `https://api.supermemory.ai/*`.
+- Values must not contain spaces.
+- If you omit `--project` for these URLs, you'll be prompted. Pressing Enter uses `default`.
+- The value is injected as a header alongside any `--header` flags.
+
+Examples:
+
+```bash
+# Explicit project
+npx install-mcp https://api.supermemory.ai/servers/my-server \
+  --client cursor \
+  --project myproj
+
+# Prompted for project (Enter defaults to "default")
+npx install-mcp https://api.supermemory.ai/servers/my-server --client cursor
+```
+
+Warp users: the generated config will include `--header "x-sm-project: <value>"` in the `args` array when installing Supermemory URLs.
+
 ### Headers Support
 
 You can pass headers for authentication or other purposes using the `--header` flag:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "install-mcp",
-	"version": "1.7.1",
+	"version": "1.8.0",
 	"description": "A CLI tool to install and manage MCP servers.",
 	"bin": {
 		"install-mcp": "./bin/run"


### PR DESCRIPTION
- Add a new CLI option --project that only applies when installing a URL on https://api.supermemory.ai/*.
- Behavior:
  - If --project is provided, it is validated (no spaces) and added as a header: x-sm-project: <value>.
  - If --project is omitted for Supermemory URLs, the installer prompts for a project. Empty input defaults to default (users can still override per LLM session).
  - The header is appended alongside any --header flags.
  - Works for both regular installs and Warp output (included in args as --header "x-sm-project: <value>").
- Does not affect non-URL installs or non-Supermemory URLs.

Docs:
- Update README with a new “Supermemory project support” section explaining:
  - When the flag applies
  - Validation rules
  - Prompting and default behavior
  - Examples and Warp notes