### PR TITLE
feat: Add Droid(Factory AI's CLI) client support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ The `--client` flag specifies which MCP client you're installing for:
 - `zed`
 - `warp` (outputs config to copy/paste into Warp's cloud-based settings)
 - `codex` (OpenAI's Codex CLI tool)
+- `droid` (Factory.AI's Droid CLI tool)
 
 ## License
 

--- a/src/client-config.ts
+++ b/src/client-config.ts
@@ -56,6 +56,12 @@ function getClientPaths(): { [key: string]: ClientInstallTarget } {
 
   return {
     claude: { type: 'file', path: defaultClaudePath, configKey: 'mcpServers' },
+    droid: {
+      type: 'file',
+      path: path.join(homeDir, '.factory', 'mcp.json'),
+      localPath: path.join(process.cwd(), '.factory', 'mcp.json'),
+      configKey: 'mcpServers',
+    },
     cline: {
       type: 'file',
       path: path.join(
@@ -145,6 +151,7 @@ function getClientPaths(): { [key: string]: ClientInstallTarget } {
 
 export const clientNames = [
   'claude',
+  'droid',
   'cline',
   'roo-cline',
   'windsurf',


### PR DESCRIPTION
### Changes Made

1. **Code Implementation** (commit cb004ca):
   - Added Droid client configuration in `src/client-config.ts`
   - Configured the MCP config path to `~/.factory/mcp.json` for global installation
   - Added support for local installation at `.factory/mcp.json` in the current directory
   - Set the config key to `mcpServers` to match the expected Droid configuration format
   - Added 'droid' to the list of supported client names

2. **Documentation Update** (commit f32a002):
   - Updated README.md to include 'droid' in the list of supported clients
   - Added a brief description: "droid (Factory.AI's Droid CLI tool)"

### Technical Details
The implementation follows the established pattern for other clients in the codebase:
- Uses a file-based configuration with JSON format
- Supports both global and local configuration files
- Integrates seamlessly with the existing install command infrastructure

### Usage Example
Users can now install MCP servers for Droid using:
```bash
# Global at  `~.factory/mcp.json`
npx -y install-mcp@latest https://api.supermemory.ai/mcp --client droid --oauth=yes

# Local at  `.factory/mcp.json`
npx -y install-mcp@latest https://api.supermemory.ai/mcp --client droid --local --oauth=yes
```

This will add the server configuration to the appropriate Droid MCP configuration file.

### Testing
The implementation has been tested to ensure proper configuration file creation and server registration.